### PR TITLE
Update image go-coffeshop-web to version v7

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: CI pipeline build new image
 
 on:
   workflow_dispatch:
@@ -121,6 +121,7 @@ jobs:
          git config --global user.email "chucthien2@gmail.com"
          git config --global user.name "tranchucthien"
          git add docker-compose.yml
+         git add manifest/
          git commit -m "Update image version for docker compose"
          git push 
     # - name: Create Pull Request
@@ -133,5 +134,5 @@ jobs:
         gh pr create \
           --base test \
           --head "$BRANCH_NAME" \
-          --title "Update image to version $VERSION" \
-          --body "This PR updates the image version to \`$VERSION\` in docker-compose.yml"
+          --title "Update image go-coffeshop-web to version $VERSION" \
+          --body "This PR updates the image version of go-coffeshop-web to version \`$VERSION\` in docker-compose and manifest"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,7 @@ services:
       context: .
       dockerfile: ./docker/Dockerfile-web
 
-    image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:latest
+    image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:v7
 
     environment:
       REVERSE_PROXY_URL: http://localhost:5000

--- a/manifest/web/web-deployment.yaml
+++ b/manifest/web/web-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             - secretRef:
                 name: postgres-db-creds
 
-          image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web
+          image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:v7
           name: web
           ports:
             - containerPort: 8888


### PR DESCRIPTION
This PR updates the image version of go-coffeshop-web to version `v7` in docker-compose and manifest