### PR TITLE
Update image go-coffeshop-web to version v9

### DIFF
--- a/.github/workflows/_01_ci_pipeline.yml
+++ b/.github/workflows/_01_ci_pipeline.yml
@@ -103,7 +103,7 @@ jobs:
 
     - name: Tag and push image to ECR
       run: |
-
+        docker pull cuongopswat/go-coffeeshop-web:latest
         docker tag cuongopswat/go-coffeeshop-web:latest 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:${{ inputs.image_version }}
         docker push 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:${{ inputs.image_version }}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,7 @@ services:
       context: .
       dockerfile: ./docker/Dockerfile-web
 
-    image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:v7
+    image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:v9
 
     environment:
       REVERSE_PROXY_URL: http://localhost:5000

--- a/manifest/web/web-deployment.yaml
+++ b/manifest/web/web-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             - secretRef:
                 name: postgres-db-creds
 
-          image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:v7
+          image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:v9
           name: web
           ports:
             - containerPort: 8888


### PR DESCRIPTION
This PR updates the image version of go-coffeshop-web to version `v9` in docker-compose and manifest