### PR TITLE
Update image go-coffeshop-web to version v2.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,7 @@ services:
       context: .
       dockerfile: ./docker/Dockerfile-web
 
-    image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:v10
+    image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:v2.0
 
     environment:
       REVERSE_PROXY_URL: http://localhost:5000

--- a/manifest/web/web-deployment.yaml
+++ b/manifest/web/web-deployment.yaml
@@ -32,4 +32,17 @@ spec:
           ports:
             - containerPort: 8888
               protocol: TCP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
       restartPolicy: Always
+      rollingUpdate:
+        maxUnavailable: 1  # means at least 1 pod will be available during the update 
+        maxSurge: 1  # means at most 1 pod will be created during the update
+
+# kubectl rollout status deployment web # to track the status of the deployment
+# kubectl rollout undo deployment web # to rollback the deployment

--- a/manifest/web/web-deployment.yaml
+++ b/manifest/web/web-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             - secretRef:
                 name: postgres-db-creds
 
-          image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:v10
+          image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:v2.0
           name: web
           ports:
             - containerPort: 8888

--- a/manifest/web/web-hpa.yaml
+++ b/manifest/web/web-hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: web-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: web
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 2


### PR DESCRIPTION
This PR updates the image version of go-coffeshop-web to version `v2.0` in docker-compose and manifest