### PR TITLE
Update image go-coffeshop-web to version v2.4.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,7 @@ services:
       context: .
       dockerfile: ./docker/Dockerfile-web
 
-    image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:v2.0
+    image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:v2.4.4
 
     environment:
       REVERSE_PROXY_URL: http://localhost:5000

--- a/manifest/web/web-deployment.yaml
+++ b/manifest/web/web-deployment.yaml
@@ -33,7 +33,7 @@ spec:
             - secretRef:
                 name: postgres-db-creds
 
-          image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:v2.0
+          image: 492804330065.dkr.ecr.us-east-2.amazonaws.com/go-coffeeshop-web:v2.4.4
           name: web
           ports:
             - containerPort: 8888


### PR DESCRIPTION
This PR updates the image version of go-coffeshop-web to version `v2.4.4` in docker-compose and manifest